### PR TITLE
Added editorType (required) to manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,5 +3,6 @@
 	"api": "1.0.0",
 	"main": "dist/code.js",
 	"ui": "dist/ui.html",
-	"id": "my-plugin-id"
+	"id": "my-plugin-id",
+	"editorType": ["figma"]
 }


### PR DESCRIPTION
I noticed the `editorType` is required upon using this template. Would be nice to update the `manifest.json` accordingly.

More info: https://www.figma.com/plugin-docs/setting-editor-type/